### PR TITLE
target common JS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "ES2020", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "es2020", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": [
       "DOM",
       "ES2020"


### PR DESCRIPTION
We are trying to use this library in a TS project that gets transpiled to common JS and the build fails due to this project having 2020 as a target. Was this intentional and if not would you consider this change?